### PR TITLE
change to callback style in bridge

### DIFF
--- a/euswank/bridge.py
+++ b/euswank/bridge.py
@@ -198,7 +198,8 @@ class EuslispProcess(Process):
                 line = self.delim.join(self.output)
                 pos = line.find(token)
                 if pos != -1:
-                    return line[pos+len(token)+1:]
+                    start = pos + len(token) + 1
+                    return line[start:]
 
 
 def eus_eval_once(cmd):

--- a/euswank/handler.py
+++ b/euswank/handler.py
@@ -121,7 +121,8 @@ class EUSwankHandler(object):
         log.info("result: %s" % result)
         errors = []
         seconds = 0.01
-        return [Symbol(":compilation-result"), errors, True, seconds, None, None]
+        return [Symbol(":compilation-result"), errors, True,
+                seconds, None, None]
 
     def swank_compile_notes_for_emacs(self, *args):
         log.warn(args)


### PR DESCRIPTION
Existing bridge waits I/O with polling that consumes CPU much.
New bridge instead gets I/O with callback invocation.
Also includes some bugfixes:

- fix: remove ansi escape character from string on getting from remote process
- improve: support getting intermediate output / error in bridge (though they are not yet passed to client)
- improve: support simple completion (Addressing #1)
- fix: replace `nil` with empty string on eval (Closes #10 )
- improve: support compilation (through it does not actually compile, but just eval)