### PR TITLE
Adapt to reader macros

### DIFF
--- a/euslime/bridge.py
+++ b/euslime/bridge.py
@@ -181,9 +181,13 @@ class EuslispProcess(Process):
         token = "token-" + str(uuid1())
         sexp = parse(cmd_str)
         dump = dumps(sexp)[1:-1].replace('\#', '#').replace('# ', '#')
+        # Will not work for cases actively containing '\#' or '# '
+        # e.g. (setq \# 1) --> ERROR
+
         cmd_str = """(let (({0} {1}))
                        (format t "{0}")
                        {0})""".format(token, dump)
+
         log.info("cmd_str: %s", cmd_str)
         self.output = Queue()
         self.error = Queue()


### PR DESCRIPTION
Probably not the best one, but a solution for #20 .

```lisp
irteusgl> #'print
;; #<compiled-code #X556e3a8>
irteusgl> (v+ #f(1 2 3) #f(10 20 30))
;; #f(11.0 22.0 33.0)
```

Will crash when user wants to actively use `\#`  or the `#` macro alone. For example in:
```lisp
(setq \# 1)
;; ERROR
```