### PR TITLE
Enhance debugger

### DIFF
--- a/euslime/bridge.py
+++ b/euslime/bridge.py
@@ -180,7 +180,7 @@ class EuslispProcess(Process):
     def exec_command(self, cmd_str):
         token = "token-" + str(uuid1())
         sexp = parse(cmd_str)
-        dump = dumps(sexp)[1:-1].replace('\#', '#').replace('# ', '#')
+        dump = dumps(sexp)[1:-1].replace(r'\#', '#').replace('# ', '#')
         # Will not work for cases actively containing '\#' or '# '
         # e.g. (setq \# 1) --> ERROR
 

--- a/euslime/handler.py
+++ b/euslime/handler.py
@@ -200,7 +200,7 @@ class EuslimeHandler(object):
         deb = self.debugger.pop(level - 1)
         if num == 0:  # QUIT
             self.debugger = []
-            self.euslisp.input('(reset)\n')
+            self.euslisp.input('reset')
         elif num == 1:  # CONTINUE
             pass
         elif num == 2:  # RESTART

--- a/euslime/protocol.py
+++ b/euslime/protocol.py
@@ -1,4 +1,3 @@
-import os
 from sexpdata import dumps
 from sexpdata import loads
 from sexpdata import Symbol
@@ -29,7 +28,7 @@ class Protocol(object):
             0,  # the thread which threw the condition
             len(self.handler.debugger),  # the depth of the condition
             [debug.message, str(), None],  # s-exp with a description
-            DebuggerHandler.restarts,  # list of available restarts for the condition
+            DebuggerHandler.restarts,  # list of available restarts
             debug.stack,  # stacktrace
             [None],  # pending continuation
         ]


### PR DESCRIPTION
Make the slime debugger:
- Close the window and go back to the repl when an option is chosen
- Abort the operation (instead of returning nil)
- Perform a simple reset of the error stack on `QUIT` and
- Provide the `CONTINUE` option for continuing in  the same stack
- Do not crash on the `show more` option of the call stack
- Do not crash when handling multiple debug windows